### PR TITLE
Automatic update using github actions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,32 @@
+name: update html files
+
+on:
+  push:
+  schedule:
+  - cron: "45 10 * * *"
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: ''
+      - name: Install Python dependencies
+        uses: py-actions/py-dependency-install@v3
+      - name: Generate html files
+        run: |
+          python test_scrape.py
+      - name: Commit files
+        run: |
+          git config --local user.email "hilmarmag@protonmail.com"
+          git config --local user.name "GitHub hilmarm action"
+          git add .
+          git commit -m "Automatic update"
+      - name: Push changes # push the output folder to your repo
+        uses: ad-m/github-push-action@master
+        with:
+          branch: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+bs4
+html5lib


### PR DESCRIPTION
Added a github action with a cron timer that runs the python scrape
script once a day, and pushes to master. Still need to add a check
when there are no updates to narva page.

Signed-off-by: Hilmar Magnusson <hilmar.magnusson@bisdn.de>